### PR TITLE
Fix weird non-english characters in mails

### DIFF
--- a/talon/quotations.py
+++ b/talon/quotations.py
@@ -540,7 +540,7 @@ def _extract_from_html(msg_body):
     #    of replacing data outside the <tag> which might be essential to
     #    the customer.
     remove_namespaces(html_tree_copy)
-    return html.tostring(html_tree_copy)
+    return html.tostring(html_tree_copy, encoding='unicode')
 
 
 def remove_namespaces(root):

--- a/talon/utils.py
+++ b/talon/utils.py
@@ -191,8 +191,11 @@ def html_fromstring(s):
 def html_document_fromstring(s):
     """Parse html tree from string. Return None if the string can't be parsed.
     """
-    if isinstance(s, six.text_type):
-        s = s.encode('utf8')
+    # html5lib doesn't allow us to pass encodings to the parser because reasons, so it defaults wo Windows-1252
+    # The decoding afterwards is done in UTF-8, and while this works fine for english alphabet characters,
+    # other characters are mis-decoded
+    # We encode the string to unicode so that it goes through the unicode flow and all is well in the world
+    s = unicode(s)
     try:
         if html_too_big(s):
             return None


### PR DESCRIPTION
When using talon to strip quotes from the HTML version of email, the HTML tree is built from a string.
The html5lib parser that Talon uses has no exposed API for providing an encoding so it defaults to Windows-1252.
After the quote stripping is done, the HTML tree is decoded back into a string using UTF-8.
While this works fine for English characters, any other character is wrongly decoded.

One fix for this is to encode the string in Unicode so it goes through a separate Unicode flow in the html5lib. After the stripping is done, the HTML tree is also decoded using Unicode.