### PR TITLE
Increase HTML tags limit

### DIFF
--- a/talon/utils.py
+++ b/talon/utils.py
@@ -264,4 +264,4 @@ _RE_EXCESSIVE_NEWLINES = re.compile("\n{2,10}")
 
 # an extensive research shows that exceeding this limit
 # might lead to excessive processing time
-_MAX_TAGS_COUNT = 419
+_MAX_TAGS_COUNT = 2000


### PR DESCRIPTION
Some emails have an obnoxious amount of HTML tags and Talon has a limit (performance reasons) on how many it can have before deciding to not parse it.
I've increased the limit from ~400 to 2000. Anything over 2000 is just ridiculous and we shouldn't even look into stripping those.
Tested with emails having up to 1200 tags and the performance impact is negligible (a matter of ms).